### PR TITLE
Update rn-fetch-blob.podspec

### DIFF
--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'React/Core'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Compatible versions for pod "React-Core" upgrading to RN 0.60.0